### PR TITLE
update mioco version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andy Russell <arussell123@gmail.com>"]
 
 [dependencies]
 env_logger = "0.3"
-mioco = "0.4.1"
+mioco = "*"
 rmp = "^0.7"
 rmp-serde = "0.9.0"
 serde = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Andy Russell <arussell123@gmail.com>"]
 
 [dependencies]
 env_logger = "0.3"
-mioco = "*"
+mioco = "0.7"
 rmp = "^0.7"
 rmp-serde = "0.9.0"
 serde = "*"


### PR DESCRIPTION
error with rustc 1.12.0-nightly (2ad5ed07f 2016-07-08)
```
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:194:5: 194:21 error: unresolved name `panic::propagate` [E0425]
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:194     panic::propagate(Box::new(Killed))
                                                                                                    ^~~~~~~~~~~~~~~~
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:194:5: 194:21 help: run `rustc --explain E0425` to see a detailed explanation
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:238:37: 238:61 error: unresolved name `panic::AssertRecoverSafe` [E0425]
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:238             let coroutine_user_fn = panic::AssertRecoverSafe(coroutine_user_fn);
                                                                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:238:37: 238:61 help: run `rustc --explain E0425` to see a detailed explanation
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:243:21: 243:37 error: unresolved name `panic::propagate` [E0425]
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:243                     panic::propagate(Box::new(Killed))
                                                                                                                    ^~~~~~~~~~~~~~~~
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:243:21: 243:37 help: run `rustc --explain E0425` to see a detailed explanation
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:239:23: 239:37 error: unresolved name `panic::recover` [E0425]
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:239             let res = panic::recover(move || {
                                                                                                                      ^~~~~~~~~~~~~~
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/coroutine.rs:239:23: 239:37 help: run `rustc --explain E0425` to see a detailed explanation
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/thread.rs:362:47: 362:63 error: unresolved name `panic::propagate` [E0425]
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/thread.rs:362             Message::PropagatePanic(cause) => panic::propagate(cause),
                                                                                                                                           ^~~~~~~~~~~~~~~~
/Users/hattori/.cargo/registry/src/github.com-1ecc6299db9ec823/mioco-0.4.1/src/thread.rs:362:47: 362:63 help: run `rustc --explain E0425` to see a detailed explanation
error: aborting due to 5 previous errors
error: Could not compile `mioco`.
```